### PR TITLE
Fix typo in Next.js skill description

### DIFF
--- a/index.html
+++ b/index.html
@@ -348,7 +348,7 @@
             <div class="details">
               <div class="top">
                 <h5>Next.js</h5>
-                <p>Moderní frontend, Komponenenty, App router...</p>
+                <p>Moderní frontend, Komponenty, App router...</p>
               </div>
               <div class="progress-bar">
                 <div class="progress" style="width: 20%">


### PR DESCRIPTION

fix Next.js skill description typo (`Komponenty`)