### PR TITLE
Fix language box centering across viewports

### DIFF
--- a/style.css
+++ b/style.css
@@ -187,7 +187,7 @@ menu .language-toggle:hover {
   flex-direction: column;
   top: 45px;
   left: 50%;
-  transform: scale(95%) translateX(-50);
+  transform: scale(95%) translateX(-50%);
   background-color: var(--background-color);
   border: 1px solid var(--border-color);
   box-shadow: 0px 0px 16px var(--card-shadow-color);


### PR DESCRIPTION

Correct `.language-box` transform to use percentage-based translation for proper centering.