### PR TITLE
fix: clamp skill description text

### DIFF
--- a/style.css
+++ b/style.css
@@ -651,10 +651,19 @@ main {
   width: 100%;
 }
 
+.experience .item .details .top h5 {
+  flex-shrink: 0;
+}
+
 .experience .item .details .top p {
   font-family: "Caveat", cursive;
   font-size: 20px;
   color: var(--primary-color-dark);
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
 }
 
 .experience .details h5 {


### PR DESCRIPTION
prevent long skill descriptions from breaking layout by truncating with ellipsis