### PR TITLE
Add alt text to language toggle flags

### DIFF
--- a/de/index.html
+++ b/de/index.html
@@ -65,10 +65,18 @@
             </svg>
           </a>
           <div class="language-box">
-            <a href="../en/index.html"><img src="../images/english.png" />English</a>
-            <a class="active"><img src="../images/german.png" />Deutsch</a>
-            <a href="../index.html"><img src="../images/czech.png" />Čeština</a>
-            <a href="../sk/index.html"><img src="../images/slovak.png" />Slovenčina</a>
+            <a href="../en/index.html"
+              ><img src="../images/english.png" alt="English flag" />English</a
+            >
+            <a class="active"
+              ><img src="../images/german.png" alt="German flag" />Deutsch</a
+            >
+            <a href="../index.html"
+              ><img src="../images/czech.png" alt="Czech flag" />Čeština</a
+            >
+            <a href="../sk/index.html"
+              ><img src="../images/slovak.png" alt="Slovak flag" />Slovenčina</a
+            >
           </div>
         </div>
         <a href="#" class="mobile-menu-toggle" aria-label="Toggle menu">

--- a/en/index.html
+++ b/en/index.html
@@ -65,10 +65,18 @@
             </svg>
           </a>
           <div class="language-box">
-            <a class="active"><img src="../images/english.png" />English</a>
-            <a href="../de/index.html"><img src="../images/german.png" />Deutsch</a>
-            <a href="../index.html"><img src="../images/czech.png" />Čeština</a>
-            <a href="../sk/index.html"><img src="../images/slovak.png" />Slovenčina</a>
+            <a class="active"
+              ><img src="../images/english.png" alt="English flag" />English</a
+            >
+            <a href="../de/index.html"
+              ><img src="../images/german.png" alt="German flag" />Deutsch</a
+            >
+            <a href="../index.html"
+              ><img src="../images/czech.png" alt="Czech flag" />Čeština</a
+            >
+            <a href="../sk/index.html"
+              ><img src="../images/slovak.png" alt="Slovak flag" />Slovenčina</a
+            >
           </div>
         </div>
         <a href="#" class="mobile-menu-toggle" aria-label="Toggle menu">

--- a/index.html
+++ b/index.html
@@ -102,11 +102,17 @@
             </svg>
           </a>
           <div class="language-box">
-            <a href="en/index.html"><img src="images/english.png" />English</a>
-            <a href="de/index.html"><img src="images/german.png" />Deutsch</a>
-            <a class="active"><img src="images/czech.png" />Čeština</a>
+            <a href="en/index.html"
+              ><img src="images/english.png" alt="English flag" />English</a
+            >
+            <a href="de/index.html"
+              ><img src="images/german.png" alt="German flag" />Deutsch</a
+            >
+            <a class="active"
+              ><img src="images/czech.png" alt="Czech flag" />Čeština</a
+            >
             <a href="sk/index.html"
-              ><img src="images/slovak.png" />Slovenčina</a
+              ><img src="images/slovak.png" alt="Slovak flag" />Slovenčina</a
             >
           </div>
         </div>

--- a/sk/index.html
+++ b/sk/index.html
@@ -65,10 +65,18 @@
             </svg>
           </a>
           <div class="language-box">
-            <a href="../en/index.html"><img src="../images/english.png" />English</a>
-            <a href="../de/index.html"><img src="../images/german.png" />Deutsch</a>
-            <a href="../index.html"><img src="../images/czech.png" />Čeština</a>
-            <a class="active"><img src="../images/slovak.png" />Slovenčina</a>
+            <a href="../en/index.html"
+              ><img src="../images/english.png" alt="English flag" />English</a
+            >
+            <a href="../de/index.html"
+              ><img src="../images/german.png" alt="German flag" />Deutsch</a
+            >
+            <a href="../index.html"
+              ><img src="../images/czech.png" alt="Czech flag" />Čeština</a
+            >
+            <a class="active"
+              ><img src="../images/slovak.png" alt="Slovak flag" />Slovenčina</a
+            >
           </div>
         </div>
         <a href="#" class="mobile-menu-toggle" aria-label="Toggle menu">


### PR DESCRIPTION
## Summary
- add descriptive alt text to language flag icons across all localized index.html files for improved accessibility

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68964a9029b0832b9eb98a798bec2d9a