### PR TITLE
Add alt text and lazy loading for images

### DIFF
--- a/de/index.html
+++ b/de/index.html
@@ -65,10 +65,10 @@
             </svg>
           </a>
           <div class="language-box">
-            <a href="../en/index.html"><img src="../images/english.png" />English</a>
-            <a class="active"><img src="../images/german.png" />Deutsch</a>
-            <a href="../index.html"><img src="../images/czech.png" />Čeština</a>
-            <a href="../sk/index.html"><img src="../images/slovak.png" />Slovenčina</a>
+            <a href="../en/index.html"><img src="../images/english.png" alt="English flag" />English</a>
+            <a class="active"><img src="../images/german.png" alt="German flag" />Deutsch</a>
+            <a href="../index.html"><img src="../images/czech.png" alt="Czech flag" />Čeština</a>
+            <a href="../sk/index.html"><img src="../images/slovak.png" alt="Slovak flag" />Slovenčina</a>
           </div>
         </div>
         <a href="#" class="mobile-menu-toggle" aria-label="Toggle menu">
@@ -113,7 +113,7 @@
     </header>
     <main id="projects">
       <div class="card">
-        <img src="../images/colorpick.png" alt="" draggable="false" />
+        <img src="../images/colorpick.png" alt="Color Picker screenshot" draggable="false" loading="lazy" />
         <span>project one</span>
         <h5>Color Picker</h5>
         <p>
@@ -137,7 +137,7 @@
             <path d="M12 5v14" /></svg></a>
       </div>
       <div class="card">
-        <img src="../images/car.png" alt="" draggable="false" />
+        <img src="../images/car.png" alt="Auto Dealership screenshot" draggable="false" loading="lazy" />
         <span>project two</span>
         <h5>Auto Dealership</h5>
         <p>
@@ -161,7 +161,7 @@
             <path d="M12 5v14" /></svg></a>
       </div>
       <div class="card">
-        <img src="../images/autoservis.png" alt="" draggable="false" />
+        <img src="../images/autoservis.png" alt="Autoservis screenshot" draggable="false" loading="lazy" />
         <span>project three</span>
         <h5>Autowerkstatt</h5>
         <p>
@@ -187,7 +187,7 @@
           </a>
       </div>
       <div class="card">
-        <img src="../images/sushi.png" alt="" draggable="false" />
+        <img src="../images/sushi.png" alt="Sakura Sushi screenshot" draggable="false" loading="lazy" />
         <span>project four</span>
         <h5>Sakura Sushi</h5>
         <p>
@@ -212,7 +212,7 @@
             <path d="M12 5v14" /></svg></a>
       </div>
       <div class="card">
-        <img src="../images/exams.png" alt="" draggable="false" />
+        <img src="../images/exams.png" alt="Testsystem screenshot" draggable="false" loading="lazy" />
         <span>project five</span>
         <h5>Testsystem</h5>
         <p>
@@ -285,7 +285,7 @@
             </div>
           </div>
           <div class="item">
-            <img src="../icons/php.svg" alt="" loading="lazy" />
+            <img src="../icons/php.svg" alt="php-icon" loading="lazy" />
             <div class="details">
               <div class="top">
                 <h5>PHP</h5>
@@ -299,7 +299,7 @@
             </div>
           </div>
           <div class="item">
-            <img src="../icons/docker.svg" alt="" loading="lazy" />
+            <img src="../icons/docker.svg" alt="docker-icon" loading="lazy" />
             <div class="details">
               <div class="top">
                 <h5>Docker</h5>
@@ -313,7 +313,7 @@
             </div>
           </div>
           <div class="item">
-            <img src="../icons/phpmyadmin.svg" alt="" loading="lazy" />
+            <img src="../icons/phpmyadmin.svg" alt="phpmyadmin-icon" loading="lazy" />
             <div class="details">
               <div class="top">
                 <h5>phpMyAdmin &amp; SQL</h5>
@@ -327,7 +327,7 @@
             </div>
           </div>
           <div class="item">
-            <img src="../icons/figma.svg" alt="" loading="lazy" />
+            <img src="../icons/figma.svg" alt="figma-icon" loading="lazy" />
             <div class="details">
               <h5>Figma</h5>
               <div class="progress-bar">

--- a/en/index.html
+++ b/en/index.html
@@ -65,10 +65,10 @@
             </svg>
           </a>
           <div class="language-box">
-            <a class="active"><img src="../images/english.png" />English</a>
-            <a href="../de/index.html"><img src="../images/german.png" />Deutsch</a>
-            <a href="../index.html"><img src="../images/czech.png" />Čeština</a>
-            <a href="../sk/index.html"><img src="../images/slovak.png" />Slovenčina</a>
+            <a class="active"><img src="../images/english.png" alt="English flag" />English</a>
+            <a href="../de/index.html"><img src="../images/german.png" alt="German flag" />Deutsch</a>
+            <a href="../index.html"><img src="../images/czech.png" alt="Czech flag" />Čeština</a>
+            <a href="../sk/index.html"><img src="../images/slovak.png" alt="Slovak flag" />Slovenčina</a>
           </div>
         </div>
         <a href="#" class="mobile-menu-toggle" aria-label="Toggle menu">
@@ -113,7 +113,7 @@
     </header>
     <main id="projects">
       <div class="card">
-        <img src="../images/colorpick.png" alt="" draggable="false" />
+        <img src="../images/colorpick.png" alt="Color Picker screenshot" draggable="false" loading="lazy" />
         <span>project one</span>
         <h5>Color Picker</h5>
         <p>
@@ -137,7 +137,7 @@
             <path d="M12 5v14" /></svg></a>
       </div>
       <div class="card">
-        <img src="../images/car.png" alt="" draggable="false" />
+        <img src="../images/car.png" alt="Auto Dealership screenshot" draggable="false" loading="lazy" />
         <span>project two</span>
         <h5>Auto Dealership</h5>
         <p>
@@ -161,7 +161,7 @@
             <path d="M12 5v14" /></svg></a>
       </div>
       <div class="card">
-        <img src="../images/autoservis.png" alt="" draggable="false" />
+        <img src="../images/autoservis.png" alt="Auto Service screenshot" draggable="false" loading="lazy" />
         <span>project three</span>
         <h5>Auto Service</h5>
         <p>
@@ -187,7 +187,7 @@
           </a>
       </div>
       <div class="card">
-        <img src="../images/sushi.png" alt="" draggable="false" />
+        <img src="../images/sushi.png" alt="Sakura Sushi screenshot" draggable="false" loading="lazy" />
         <span>project four</span>
         <h5>Sakura Sushi</h5>
         <p>
@@ -212,7 +212,7 @@
             <path d="M12 5v14" /></svg></a>
       </div>
       <div class="card">
-        <img src="../images/exams.png" alt="" draggable="false" />
+        <img src="../images/exams.png" alt="Testing system screenshot" draggable="false" loading="lazy" />
         <span>project five</span>
         <h5>Testing System</h5>
         <p>
@@ -285,7 +285,7 @@
             </div>
           </div>
           <div class="item">
-            <img src="../icons/php.svg" alt="" loading="lazy" />
+            <img src="../icons/php.svg" alt="php-icon" loading="lazy" />
             <div class="details">
               <div class="top">
                 <h5>PHP</h5>
@@ -299,7 +299,7 @@
             </div>
           </div>
           <div class="item">
-            <img src="../icons/docker.svg" alt="" loading="lazy" />
+            <img src="../icons/docker.svg" alt="docker-icon" loading="lazy" />
             <div class="details">
               <div class="top">
                 <h5>Docker</h5>
@@ -313,7 +313,7 @@
             </div>
           </div>
           <div class="item">
-            <img src="../icons/phpmyadmin.svg" alt="" loading="lazy" />
+            <img src="../icons/phpmyadmin.svg" alt="phpmyadmin-icon" loading="lazy" />
             <div class="details">
               <div class="top">
                 <h5>phpMyAdmin &amp; SQL</h5>
@@ -327,7 +327,7 @@
             </div>
           </div>
           <div class="item">
-            <img src="../icons/figma.svg" alt="" loading="lazy" />
+            <img src="../icons/figma.svg" alt="figma-icon" loading="lazy" />
             <div class="details">
               <h5>Figma</h5>
               <div class="progress-bar">

--- a/index.html
+++ b/index.html
@@ -102,11 +102,11 @@
             </svg>
           </a>
           <div class="language-box">
-            <a href="en/index.html"><img src="images/english.png" />English</a>
-            <a href="de/index.html"><img src="images/german.png" />Deutsch</a>
-            <a class="active"><img src="images/czech.png" />Čeština</a>
+            <a href="en/index.html"><img src="images/english.png" alt="English flag" />English</a>
+            <a href="de/index.html"><img src="images/german.png" alt="German flag" />Deutsch</a>
+            <a class="active"><img src="images/czech.png" alt="Czech flag" />Čeština</a>
             <a href="sk/index.html"
-              ><img src="images/slovak.png" />Slovenčina</a
+              ><img src="images/slovak.png" alt="Slovak flag" />Slovenčina</a
             >
           </div>
         </div>
@@ -153,7 +153,7 @@
     </header>
     <main id="projects">
       <div class="card">
-        <img src="images/colorpick.png" alt="" draggable="false" />
+        <img src="images/colorpick.png" alt="Color Picker screenshot" draggable="false" loading="lazy" />
         <div>
           <span>project one</span>
           <h5>Color Picker</h5>
@@ -180,7 +180,7 @@
         </div>
       </div>
       <div class="card">
-        <img src="images/car.png" alt="" draggable="false" />
+        <img src="images/car.png" alt="Auto Dealership screenshot" draggable="false" loading="lazy" />
         <span>project two</span>
         <h5>Auto Dealership</h5>
         <p>
@@ -205,7 +205,7 @@
         ></a>
       </div>
       <div class="card">
-        <img src="images/autoservis.png" alt="" draggable="false" />
+        <img src="images/autoservis.png" alt="Autoservis screenshot" draggable="false" loading="lazy" />
         <span>project three</span>
         <h5>Autoservis</h5>
         <p>
@@ -231,7 +231,7 @@
         ></a>
       </div>
       <div class="card">
-        <img src="images/sushi.png" alt="" draggable="false" />
+        <img src="images/sushi.png" alt="Sakura Sushi screenshot" draggable="false" loading="lazy" />
         <span>project four</span>
         <h5>Sakura Sushi</h5>
         <p>
@@ -257,7 +257,7 @@
         ></a>
       </div>
       <div class="card">
-        <img src="images/exams.png" alt="" draggable="false" />
+        <img src="images/exams.png" alt="Testovací systém screenshot" draggable="false" loading="lazy" />
         <span>project five</span>
         <h5>Testovací systém</h5>
         <p>
@@ -331,7 +331,7 @@
             </div>
           </div>
           <div class="item">
-            <img src="icons/php.svg" alt="" loading="lazy" />
+            <img src="icons/php.svg" alt="php-icon" loading="lazy" />
             <div class="details">
               <div class="top">
                 <h5>PHP</h5>
@@ -345,7 +345,7 @@
             </div>
           </div>
           <div class="item">
-            <img src="icons/docker.svg" alt="" loading="lazy" />
+            <img src="icons/docker.svg" alt="docker-icon" loading="lazy" />
             <div class="details">
               <div class="top">
                 <h5>Docker</h5>
@@ -359,7 +359,7 @@
             </div>
           </div>
           <div class="item">
-            <img src="icons/phpmyadmin.svg" alt="" loading="lazy" />
+            <img src="icons/phpmyadmin.svg" alt="phpmyadmin-icon" loading="lazy" />
             <div class="details">
               <div class="top">
                 <h5>phpMyAdmin &amp; SQL</h5>
@@ -373,7 +373,7 @@
             </div>
           </div>
           <div class="item">
-            <img src="icons/figma.svg" alt="" loading="lazy" />
+            <img src="icons/figma.svg" alt="figma-icon" loading="lazy" />
             <div class="details">
               <h5>Figma</h5>
               <div class="progress-bar">

--- a/sk/index.html
+++ b/sk/index.html
@@ -65,10 +65,10 @@
             </svg>
           </a>
           <div class="language-box">
-            <a href="../en/index.html"><img src="../images/english.png" />English</a>
-            <a href="../de/index.html"><img src="../images/german.png" />Deutsch</a>
-            <a href="../index.html"><img src="../images/czech.png" />Čeština</a>
-            <a class="active"><img src="../images/slovak.png" />Slovenčina</a>
+            <a href="../en/index.html"><img src="../images/english.png" alt="English flag" />English</a>
+            <a href="../de/index.html"><img src="../images/german.png" alt="German flag" />Deutsch</a>
+            <a href="../index.html"><img src="../images/czech.png" alt="Czech flag" />Čeština</a>
+            <a class="active"><img src="../images/slovak.png" alt="Slovak flag" />Slovenčina</a>
           </div>
         </div>
         <a href="#" class="mobile-menu-toggle" aria-label="Toggle menu">
@@ -113,7 +113,7 @@
     </header>
     <main id="projects">
       <div class="card">
-        <img src="../images/colorpick.png" alt="" draggable="false" />
+        <img src="../images/colorpick.png" alt="Color Picker screenshot" draggable="false" loading="lazy" />
         <span>project one</span>
         <h5>Color Picker</h5>
         <p>
@@ -137,7 +137,7 @@
             <path d="M12 5v14" /></svg></a>
       </div>
       <div class="card">
-        <img src="../images/car.png" alt="" draggable="false" />
+        <img src="../images/car.png" alt="Auto Dealership screenshot" draggable="false" loading="lazy" />
         <span>project two</span>
         <h5>Auto Dealership</h5>
         <p>
@@ -161,7 +161,7 @@
             <path d="M12 5v14" /></svg></a>
       </div>
       <div class="card">
-        <img src="../images/autoservis.png" alt="" draggable="false" />
+        <img src="../images/autoservis.png" alt="Autoservis screenshot" draggable="false" loading="lazy" />
         <span>project three</span>
         <h5>Autoservis</h5>
         <p>
@@ -187,7 +187,7 @@
           </a>
       </div>
       <div class="card">
-        <img src="../images/sushi.png" alt="" draggable="false" />
+        <img src="../images/sushi.png" alt="Sakura Sushi screenshot" draggable="false" loading="lazy" />
         <span>project four</span>
         <h5>Sakura Sushi</h5>
         <p>
@@ -212,7 +212,7 @@
             <path d="M12 5v14" /></svg></a>
       </div>
       <div class="card">
-        <img src="../images/exams.png" alt="" draggable="false" />
+        <img src="../images/exams.png" alt="Testovací systém screenshot" draggable="false" loading="lazy" />
         <span>project five</span>
         <h5>Testovací systém</h5>
         <p>
@@ -285,7 +285,7 @@
             </div>
           </div>
           <div class="item">
-            <img src="../icons/php.svg" alt="" loading="lazy" />
+            <img src="../icons/php.svg" alt="php-icon" loading="lazy" />
             <div class="details">
               <div class="top">
                 <h5>PHP</h5>
@@ -299,7 +299,7 @@
             </div>
           </div>
           <div class="item">
-            <img src="../icons/docker.svg" alt="" loading="lazy" />
+            <img src="../icons/docker.svg" alt="docker-icon" loading="lazy" />
             <div class="details">
               <div class="top">
                 <h5>Docker</h5>
@@ -313,7 +313,7 @@
             </div>
           </div>
           <div class="item">
-            <img src="../icons/phpmyadmin.svg" alt="" loading="lazy" />
+            <img src="../icons/phpmyadmin.svg" alt="phpmyadmin-icon" loading="lazy" />
             <div class="details">
               <div class="top">
                 <h5>phpMyAdmin &amp; SQL</h5>
@@ -327,7 +327,7 @@
             </div>
           </div>
           <div class="item">
-            <img src="../icons/figma.svg" alt="" loading="lazy" />
+            <img src="../icons/figma.svg" alt="figma-icon" loading="lazy" />
             <div class="details">
               <h5>Figma</h5>
               <div class="progress-bar">


### PR DESCRIPTION
## Summary
- add descriptive alt text to language flags, project screenshots, and skill icons across all index pages
- defer offscreen project images with loading="lazy"

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68964a8d2074832b872b66ce0b0eb468