### PR TITLE
Update portfolio headings to IT Developer

### DIFF
--- a/de/index.html
+++ b/de/index.html
@@ -5,13 +5,13 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta
       name="description"
-      content="Kurze Zusammenfassung von Marek Bulejčíks Frontend-Fähigkeiten und präsentierten Projekten"
+      content="IT-Entwickler, der Lösungen auf Web- und prozessbasierten Plattformen entwirft und implementiert"
     />
     <link rel="stylesheet" href="../style.css" />
     <link rel="shortcut icon" href="../icons/code.svg" type="image/x-icon" />
     <script src="../script.js"></script>
 
-    <title>Marek Bulejčík | Frontend Developer</title>
+    <title>Marek Bulejčík | IT Developer</title>
   </head>
   <body>
     <nav id="navbar">
@@ -111,16 +111,16 @@
     </nav>
     <header>
       <p>Marek Bulejčík</p>
-      <h1>Frontend developer</h1>
+      <h1>IT Developer</h1>
       <h5>
         Ich bin <strong>19 Jahre alt</strong> und habe
         <strong>meine Hochschulreife</strong> mit Schwerpunkt
         <strong>IT</strong> abgeschlossen. <br />Während meines Studiums habe ich mich mit
-        Webentwicklung beschäftigt, insbesondere Frontend, und durch
+        Webentwicklung und Prozesslösungen beschäftigt und durch
         <strong>eigene Projekte</strong> habe ich
         <strong>praktische Erfahrungen</strong> gesammelt. Ich lerne gerne, schreibe
         <strong>sauberen Code</strong> und möchte mich weiter <strong>entwickeln</strong> im
-        Team als <strong>Frontend-Entwickler</strong>.
+        Team als <strong>IT-Entwickler</strong>.
       </h5>
     </header>
     <main id="projects">

--- a/en/index.html
+++ b/en/index.html
@@ -5,13 +5,13 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta
       name="description"
-      content="Short summary of Marek Bulejčík’s frontend skills and showcased projects"
+      content="IT developer designing and implementing solutions across web and process-based platforms"
     />
     <link rel="stylesheet" href="../style.css" />
     <link rel="shortcut icon" href="../icons/code.svg" type="image/x-icon" />
     <script src="../script.js"></script>
 
-    <title>Marek Bulejčík | Frontend Developer</title>
+    <title>Marek Bulejčík | IT Developer</title>
   </head>
   <body>
     <nav id="navbar">
@@ -111,16 +111,16 @@
     </nav>
     <header>
       <p>Marek Bulejčík</p>
-      <h1>Frontend developer</h1>
+      <h1>IT Developer</h1>
       <h5>
         I am <strong>19 years old</strong> and have completed my
         <strong>high school education with diploma</strong> in
         <strong>IT</strong>. <br />During my studies, I've been creating
-        websites, especially frontend, and through
+        websites and process-based solutions, and through
         <strong>my own projects</strong> I've gained
         <strong>practical experience</strong>. I enjoy learning, writing
         <strong>clean code</strong> and want to further <strong>develop</strong> in
-        a team as a <strong>frontend developer</strong>.
+        a team as an <strong>IT developer</strong>.
       </h5>
     </header>
     <main id="projects">

--- a/index.html
+++ b/index.html
@@ -5,12 +5,12 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta
       name="description"
-      content="Krátké shrnutí frontendových dovedností Marka Bulejčíka a představených projektů"
+      content="IT vývojář navrhující a implementující řešení napříč webovými a procesními platformami"
     />
     <link rel="stylesheet" href="style.css" />
     <link rel="shortcut icon" href="icons/code.svg" type="image/x-icon" />
     <script src="script.js"></script>
-    <title>Marek Bulejčík | Frontend Developer</title>
+    <title>Marek Bulejčík | IT Developer</title>
   </head>
   <body>
     <nav id="navbar">
@@ -157,15 +157,15 @@
     </nav>
     <header>
       <p>Marek Bulejčík</p>
-      <h1>Frontend developer</h1>
+      <h1>IT Developer</h1>
       <h5>
         Je mi <strong>19 let</strong> a mám dokončené
         <strong>středoškolské vzdělání s maturitou</strong> v oboru
-        <strong>IT</strong>. <br />Během studia jsem se věnoval tvorbě webů,
-        zejména frontendu, a díky <strong>vlastním projektům</strong> jsem
+        <strong>IT</strong>. <br />Během studia jsem se věnoval tvorbě webů a
+        procesních řešení a díky <strong>vlastním projektům</strong> jsem
         získal <strong>praktické zkušenosti</strong>. Rád se učím, píšu
         <strong>čistý kód</strong> a chci se dál <strong>rozvíjet</strong> v
-        týmu jako <strong>frontend developer</strong>.
+        týmu jako <strong>IT developer</strong>.
       </h5>
     </header>
     <main id="projects">

--- a/sk/index.html
+++ b/sk/index.html
@@ -5,13 +5,13 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta
       name="description"
-      content="Stručný prehľad frontendových zručností Mareka Bulejčíka a ukázaných projektov"
+      content="IT vývojár navrhujúci a implementujúci riešenia naprieč webovými a procesnými platformami"
     />
     <link rel="stylesheet" href="../style.css" />
     <link rel="shortcut icon" href="../icons/code.svg" type="image/x-icon" />
     <script src="../script.js"></script>
 
-    <title>Marek Bulejčík | Frontend Developer</title>
+    <title>Marek Bulejčík | IT Developer</title>
   </head>
   <body>
     <nav id="navbar">
@@ -111,16 +111,16 @@
     </nav>
     <header>
       <p>Marek Bulejčík</p>
-      <h1>Frontend developer</h1>
+      <h1>IT Developer</h1>
       <h5>
         Mám <strong>19 rokov</strong> a mám ukončené
         <strong>stredoškolské vzdelanie s maturitou</strong> v odbore
         <strong>IT</strong>. <br />Počas štúdia som sa venoval
-        tvorbe webov, najmä frontendu, a vďaka
+        tvorbe webov a procesných riešení a vďaka
         <strong>vlastným projektom</strong> som získal
         <strong>praktické skúsenosti</strong>. Rád sa učím, píšem
         <strong>čistý kód</strong> a chcem sa ďalej <strong>rozvíjať</strong> v
-        tíme ako <strong>frontend developer</strong>.
+        tíme ako <strong>IT developer</strong>.
       </h5>
     </header>
     <main id="projects">


### PR DESCRIPTION
## Summary
- Refine portfolio meta descriptions to highlight IT development focus across all language versions
- Replace all "Frontend developer" headings and references with "IT Developer" with updated descriptions

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6896550deb24832badf26b29fa0d0a89